### PR TITLE
Adds scroll layout demo

### DIFF
--- a/app/src/main/java/com/vuzix/ultralite/sample/MainActivity.java
+++ b/app/src/main/java/com/vuzix/ultralite/sample/MainActivity.java
@@ -266,7 +266,7 @@ public class MainActivity extends AppCompatActivity {
             ultralite.setLayout(Layout.SCROLL, 0, true);
 
             ultralite.scrollLayoutConfig(sliceHeight, 5, 500, false);
-            String teleprompterContents = getApplication().getString(R.string.gettysburg_address);
+            String teleprompterContents = getApplication().getString(R.string.scroll_layout_demo_text);
             TextToImageSlicer slicer = new TextToImageSlicer(teleprompterContents, sliceHeight, fontSize);
 
             while(slicer.hasMoreSlices()) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,4 +7,8 @@
     <string name="glasses_connected">Glasses connected</string>
     <string name="run_demo">Run Demo</string>
     <string name="send_notification">Send Notification</string>
+    <string name="gettysburg_address" translatable="false">
+        The text can also scroll like a teleprompter with the scroll layout. This layout also
+        supports several configuration options such as font size and scroll speed.
+    </string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,7 +7,7 @@
     <string name="glasses_connected">Glasses connected</string>
     <string name="run_demo">Run Demo</string>
     <string name="send_notification">Send Notification</string>
-    <string name="gettysburg_address" translatable="false">
+    <string name="scroll_layout_demo_text" translatable="false">
         The text can also scroll like a teleprompter with the scroll layout. This layout also
         supports several configuration options such as font size and scroll speed.
     </string>


### PR DESCRIPTION
This adds a teleprompter-like demo of the new scroll layout. The text will automatically show after the text wrapping demo. After the demo, the canvas is reset back to its previous layout state and continues the rest of the demo.